### PR TITLE
Fix len to strdisplaywidth when calculate field width

### DIFF
--- a/autoload/rainbow_csv.vim
+++ b/autoload/rainbow_csv.vim
@@ -582,7 +582,7 @@ func! s:calc_column_sizes(delim, policy)
             if len(result) <= fnum
                 call add(result, 0)
             endif
-            let result[fnum] = max([result[fnum], len(field)])
+            let result[fnum] = max([result[fnum], strdisplaywidth(field)])
         endfor
     endfor
     return result
@@ -607,7 +607,7 @@ func! rainbow_csv#csv_align()
                 break " Should never happen
             endif
             let field = rainbow_csv#strip_spaces(fields[fnum])
-            let delta_len = column_sizes[fnum] - len(field)
+            let delta_len = column_sizes[fnum] - strdisplaywidth(field)
             if delta_len >= 0
                 let field = field . repeat(' ', delta_len + 1)
             endif


### PR DESCRIPTION
`strdisplaywidth` will return the real width when the string is display on streen. `len` is just byte size, will look strange when string contains character more than one byte especially for CJK text.

https://renenyffenegger.ch/notes/development/vim/script/vimscript/functions/_str_len_width_chars_etc