### PR TITLE
Allow user to override data storage directories.

### DIFF
--- a/autoload/rainbow_csv.vim
+++ b/autoload/rainbow_csv.vim
@@ -6,9 +6,9 @@
 "==============================================================================
 
 let s:max_columns = exists('g:rcsv_max_columns') ? g:rcsv_max_columns : 30
-let s:rb_storage_dir = $HOME . '/.rainbow_csv_storage'
-let s:table_names_settings = $HOME . '/.rbql_table_names'
-let s:rainbow_table_index = $HOME . '/.rbql_table_index'
+let s:rb_storage_dir = exists('g:rb_storage_dir') ? g:rb_storage_dir : $HOME . '/.rainbow_csv_storage'
+let s:table_names_settings = exists('g:table_names_settings') ? g:table_names_settings : $HOME . '/.rbql_table_names'
+let s:rainbow_table_index = exists('g:rainbow_table_index') ? g:rainbow_table_index : $HOME . '/.rbql_table_index'
 
 let s:script_folder_path = expand('<sfile>:p:h:h')
 let s:python_env_initialized = 0


### PR DESCRIPTION
The global variables `g:rb_storage_dir`, `g:table_name_settings` and `g:rainbow_table_index` set their local script counterparts in `autoload/rainbow_csv.vim`.

My usecase for this is to solve #16. As not all systems conform to the XDG Base standards, the local variables still default to their original locations, so as to avoid breaking existing configurations.

*edit: fixed formatting*